### PR TITLE
fix: suppress webpack critical dependency warnings

### DIFF
--- a/apps/drizzleasy/package.json
+++ b/apps/drizzleasy/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@remcostoeten/drizzleasy",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "description": "Ultra-simple, type-safe CRUD operations for Next.js with Drizzle ORM",
     "type": "module",
     "main": "dist/index.js",

--- a/apps/drizzleasy/src/database/config-loader.ts
+++ b/apps/drizzleasy/src/database/config-loader.ts
@@ -149,7 +149,11 @@ async function safeImport(modulePath: string): Promise<any> {
         const normalizedPath = modulePath.replace(/\\/g, '/')
         
         // Try dynamic import first (ES modules)
-        const module = await import(/* @vite-ignore */ normalizedPath)
+        const module = await import(
+            /* webpackIgnore: true */
+            /* @vite-ignore */
+            normalizedPath
+        )
         return module
     } catch (error) {
         // Enhanced error logging for debugging
@@ -183,17 +187,29 @@ async function safeImportForNextJS(modulePath: string): Promise<any> {
         
         // First attempt: relative path import
         try {
-            const module = await import(/* @vite-ignore */ relativePath)
+            const module = await import(
+                /* webpackIgnore: true */
+                /* @vite-ignore */
+                relativePath
+            )
             return module
         } catch (relativeError) {
             // Second attempt: absolute path with file:// protocol
             try {
                 const fileUrl = `file://${modulePath}`
-                const module = await import(/* @vite-ignore */ fileUrl)
+                const module = await import(
+                    /* webpackIgnore: true */
+                    /* @vite-ignore */
+                    fileUrl
+                )
                 return module
             } catch (fileUrlError) {
                 // Third attempt: standard absolute path
-                const module = await import(/* @vite-ignore */ modulePath)
+                const module = await import(
+                    /* webpackIgnore: true */
+                    /* @vite-ignore */
+                    modulePath
+                )
                 return module
             }
         }


### PR DESCRIPTION
- Add webpackIgnore magic comments to dynamic imports in config-loader.ts
- Fixes webpack warnings about critical dependencies in Next.js builds
- Version bump to 0.13.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic import handling to avoid unintended bundling, enhancing compatibility with Next.js and Vite.
  * Reduced runtime issues when loading database configurations in different build environments.

* **Chores**
  * Bumped package version to 0.13.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->